### PR TITLE
fix compile errors on centos7.6

### DIFF
--- a/Common/CMakeLists.txt
+++ b/Common/CMakeLists.txt
@@ -6,7 +6,7 @@ endif()
 
 project(S5Common)
 set(CMAKE_C_FLAGS   "-Wall -Wconversion -std=c99 -I/usr/include ${CXX_FLAG_GCOV}")
-set(CMAKE_CXX_FLAGS   "-Wall -Wconversion -fPIC ${CXX_FLAG_GCOV}")
+set(CMAKE_CXX_FLAGS   "-Wall -std=c++11 -Wconversion -fPIC ${CXX_FLAG_GCOV}")
 
 set(CMAKE_CXX_FLAGS_DEBUG  "-O0 -g ")
 set(CMAKE_CXX_COMPILER g++)

--- a/Common/include/s5message.h
+++ b/Common/include/s5message.h
@@ -207,7 +207,7 @@ struct s5_message_head
 	uint8_t		    reserve[1];		///< reserve.
 };
 
-static_assert(sizeof(s5_message_head) == 64);
+static_assert(sizeof(s5_message_head) == 64, "s5_message_head");
 
 /**
  * s5message's data structure definition.
@@ -235,7 +235,7 @@ struct s5_handshake_message {
 	uint16_t rsv1;
 	uint64_t rsv2;
 };
-static_assert(sizeof(struct s5_handshake_message) == 32);
+static_assert(sizeof(struct s5_handshake_message) == 32, "s5_handshake_message");
 #pragma pack()
 
 

--- a/s5afs/include/afs_flash_store.h
+++ b/s5afs/include/afs_flash_store.h
@@ -27,7 +27,7 @@ struct lmt_key
 	int64_t rsv1;
 	int64_t rsv2;
 };
-static_assert(sizeof(lmt_key) == 32);
+static_assert(sizeof(lmt_key) == 32, "lmt_key");
 enum EntryStatus: uint32_t {
 	UNINIT = 0, //not initialized
 	NORMAL = 1,
@@ -44,7 +44,7 @@ struct lmt_entry
 	lmt_entry* prev_snap;
 	void* waiting_io;
 };
-static_assert(sizeof(lmt_entry) == 32);
+static_assert(sizeof(lmt_entry) == 32, "lmt_entry");
 
 inline bool operator == (const lmt_key &k1, const lmt_key &k2) { return k1.vol_id == k2.vol_id && k1.slba == k2.slba; }
 


### PR DESCRIPTION
For gcc version under gcc 6, static_assert need 2 arguments. Up versions can accept 1 or 2 arguments. Also, we need to set cxx_flags -std=c++11

Test both on Ubuntu 18.04 && CentOS 7.6