### PR TITLE
修复删除zookeeper节点的函数bug

### DIFF
--- a/common/src/pf_zk_client.cpp
+++ b/common/src/pf_zk_client.cpp
@@ -186,7 +186,11 @@ int PfZkClient::wait_lock(const std::string& lock_path, const char* myid)
 
 int PfZkClient::delete_node(const std::string& node_path)
 {
-	return zoo_delete(zkhandle, node_path.c_str(), -1);
+	// 传入的路径参数不是以/开头，需要加上/pureflash等前缀
+	std::string full_path=node_path;
+	if(node_path[0] != '/')
+		full_path="/pureflash/"+cluster_name+"/"+node_path;
+	return zoo_delete(zkhandle, full_path.c_str(), -1);
 }
 
 std::string PfZkClient::get_data_port(int store_id,  int port_idx)

--- a/pfs/src/pf_cluster.cpp
+++ b/pfs/src/pf_cluster.cpp
@@ -87,7 +87,10 @@ int register_store_node(int store_id, const char* mngt_ip)
 	snprintf(zk_node_name, sizeof(zk_node_name), "stores/%d/mngt_ip", store_id);
 
 
-	app_context.zk_client.delete_node(zk_node_name);
+	rc = app_context.zk_client.delete_node(zk_node_name);
+
+	if(rc != ZOK)
+		S5LOG_WARN("Failed to delete zookeeper node %s rc:%d", zk_node_name, rc);
 
 	if ((rc = app_context.zk_client.create_node(zk_node_name, false, mngt_ip)) != ZOK)
 		return rc;


### PR DESCRIPTION
main函数调用register_store_node注册zookeeper节点时，需要调用app_context.zk_client.delete_node删除stores/$store_id/mngt_ip节点。传入的路径只有一半，直接删除会返回-8，表示参数不对。如果配置文件中修改mngt_ip时会失效，还是之前的ip。