### PR TITLE
Prevent linker from removing shared library rte_mempool_ring

### DIFF
--- a/pfs/CMakeLists.txt
+++ b/pfs/CMakeLists.txt
@@ -27,8 +27,13 @@ set(CMAKE_C_FLAGS   "-Wall -Wno-conversion -Wno-sign-compare -std=c99 -fms-exten
 set(CMAKE_CXX_FLAGS   "-Wall -Wconversion -Wno-sign-compare  -fms-extensions -Wno-variadic-macros -Wno-format-truncation -I/usr/include -D_XOPEN_SOURCE ${C_FLAG_GCOV}")
 set(CMAKE_C_FLAGS_DEBUG  "-O0 -g -DDEBUG ")
 set(CMAKE_CXX_FLAGS_DEBUG  "-O0 -g -DDEBUG ")
+# The rte_mempool_ring library provides ring-based mempool implementations
+# (e.g., ring_mp_mc, ring_sp_sc) and registers them via RTE_MEMPOOL_REGISTER_OPS,
+# so that rte_mempool can select the appropriate ops during mempool creation.
+# Use -Wl,--no-as-needed to prevent linker from dropping unused shared libraries
+set(LIBRTE_MEMPOOL_RING "-Wl,--no-as-needed -lrte_mempool_ring")
 set(SPDKLIBS spdk_nvme spdk_env_dpdk spdk_util spdk_log spdk_sock spdk_trace spdk_json spdk_jsonrpc spdk_rpc spdk_vfio_user)
-set(DPDKLIBS rte_eal rte_mempool rte_ring rte_telemetry rte_kvargs rte_pci rte_bus_pci rte_mempool_ring)
+set(DPDKLIBS rte_eal rte_mempool rte_ring rte_telemetry rte_kvargs rte_pci rte_bus_pci)
 add_definitions(-D_XOPEN_SOURCE)
 #set(CMAKE_CXX_COMPILER g++)
 
@@ -98,7 +103,7 @@ add_executable(pfs  ${S5AFS_SRC} ${HTTP_SRC} ${INCS})
 set_target_properties(pfs PROPERTIES SKIP_BUILD_RPATH true)
 #find_library(ZOOKEEPER_LIB NAMES libzookeeper_mt.a zookeeper_mt)
 
-TARGET_LINK_LIBRARIES(pfs rdmacm ibverbs pthread zookeeper_mt  hashtable uuid ${SPDKLIBS} ${DPDKLIBS} s5common nlohmann_json::nlohmann_json
+TARGET_LINK_LIBRARIES(pfs rdmacm ibverbs pthread zookeeper_mt  hashtable uuid ${LIBRTE_MEMPOOL_RING} ${SPDKLIBS} ${DPDKLIBS} s5common nlohmann_json::nlohmann_json
 	aio curl  ${THIRDPARTY}/isa-l_crypto/.libs/libisal_crypto.a libsgutils2.a)
 IF(WITH_IOURING)
 	TARGET_LINK_LIBRARIES(pfs  uring)


### PR DESCRIPTION
Ensure `librte_mempool_ring.so` is retained during linking even if symbols are not directly referenced at build time. It provides ops like `ring_mp_mc` registered via `RTE_MEMPOOL_REGISTER_OPS` used by `rte_mempool_create()` internally.
If this shared library is not loaded at runtime (e.g., dropped by the linker), 
`rte_mempool_create() → rte_mempool_set_ops_byname()` will fail with -EINVAL, since the requested ops are not found.