### PR TITLE
fix: calculate error, should be modified

### DIFF
--- a/common/include/pf_volume_type.h
+++ b/common/include/pf_volume_type.h
@@ -2,9 +2,9 @@
 #define pf_volume_type_h__
 
 
-#define SHARD_ID(x)        ((x) & 0xffffffffffffff00LL)
-#define SHARD_INDEX(x)    (((x) & 0x0000000000ffff00LL) >> 8)
-#define REPLICA_INDEX(x)   ((x) & 0x00000000000000ffLL)
+#define SHARD_ID(x)        ((x) & 0xfffffffffffffff0LL)
+#define SHARD_INDEX(x)    (((x) & 0x0000000000fffff0LL) >> 4)
+#define REPLICA_INDEX(x)   ((x) & 0x000000000000000fLL)
 #define VOLUME_ID(x)        ((x) & 0xffffffffff000000LL)
 
 struct volume_id_t {


### PR DESCRIPTION
jconductor volume_id shard_id replica_id 生成方式
v.id = S5Database.getInstance().queryLongValue("select NEXTVAL(seq_gen)  as val") << 24;
shard.id = v.id | (shardIndex << 4);
r.id = shard.id | i; // i：[0, v.rep_count]

在pfs中计算replica index
#define REPLICA_INDEX(x)   ((x) & 0x00000000000000ffLL)
rep_id是1140850705，转换为2进制是0100 0100 0000 0000 0000 0000 0001 0001
经过计算是1 0001，replica index是17了，但是，2副本的volume，replica index最大是1

导致数据恢复过程中产生问题，需要修改replica index等计算方式:
#define SHARD_ID(x)        ((x) & 0xfffffffffffffff0LL)
#define SHARD_INDEX(x)    (((x) & 0x0000000000fffff0LL) >> 4)
#define REPLICA_INDEX(x)   ((x) & 0x000000000000000fLL)

