### PR TITLE
fix: count is free, space is used

### DIFF
--- a/pfs/src/pf_server.cpp
+++ b/pfs/src/pf_server.cpp
@@ -446,7 +446,7 @@ void server_cron_proc(void)
 
 		for (auto disk : app_context.trays) {
 			int cnt = disk->event_queue->sync_invoke([disk]()->int{
-				return disk->free_obj_queue.space();
+				return disk->free_obj_queue.count();
 			});
 
                         uint64_t free_size = cnt * disk->head.objsize;


### PR DESCRIPTION
free_obj_queue初始化时count是一共可以使用的空间object的个数
free_obj_queue.count()表示空闲object的个数
free_obj_queue.space()表示已经使用的object的个数